### PR TITLE
chore(flutter): bump Kotlin Version to 1.5.20

### DIFF
--- a/flutter/android/build.gradle
+++ b/flutter/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.famedly.flutter_olm'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.20'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
This is necessary for building this library in newer version of Flutter