### PR TITLE
fix: use correct CMakeLists.txt file for Android

### DIFF
--- a/flutter/android/build.gradle
+++ b/flutter/android/build.gradle
@@ -58,7 +58,7 @@ android {
 
     externalNativeBuild {
         cmake {
-            path "../ios/CMakeLists.txt"
+            path "../../CMakeLists.txt"
         }
     }
 


### PR DESCRIPTION
Changes the used `CMakeLists.txt` to the relative `../..` instead of the one bundled into the `../ios` one. Though the files are same, there's a tiny difference : Whereas Linux resolves the symlink and properly builds olm, on Windows, the Android NDK does not seem to like that. If we directly state `../..` instead, the Android NDK properly detects the OLM source location on Windows too.