### PR TITLE
Deprecate writeAsciiToMemory

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,7 @@ on:
 # Publish using the reusable workflow from dart-lang.
 # Slightly modified to run our prep script first.
 jobs:
+  
   build_js:
     environment: pub.dev
     runs-on: ubuntu-latest
@@ -22,6 +23,7 @@ jobs:
         with:
           name: olm.zip
           path: olm.zip
+
   publish:
     needs: [build_js]
     name: Publish to pub.dev

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,22 @@ on:
 # Publish using the reusable workflow from dart-lang.
 # Slightly modified to run our prep script first.
 jobs:
+  build_js:
+    environment: pub.dev
+    runs-on: ubuntu-latest
+    container: docker.io/emscripten/emsdk:latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build JS and WASM
+        run: |
+          make js
+          zip olm.zip javascript/olm.js javascript/olm.wasm javascript/olm_legacy.js
+      - uses: actions/upload-artifact@v3
+        with:
+          name: olm.zip
+          path: olm.zip
   publish:
+    needs: [build_js]
     name: Publish to pub.dev
     environment: pub.dev
     permissions:
@@ -39,21 +54,6 @@ jobs:
       - name: Publish to pub.dev
         run: dart pub publish -f
         working-directory: publishing/flutter
-  
-  build_js:
-    environment: pub.dev
-    runs-on: ubuntu-latest
-    container: docker.io/emscripten/emsdk:latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Build JS and WASM
-        run: |
-          make js
-          zip olm.zip javascript/olm.js javascript/olm.wasm javascript/olm_legacy.js
-      - uses: actions/upload-artifact@v3
-        with:
-          name: olm.zip
-          path: olm.zip
 
   create_release:
     needs: [build_js]

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ JS_ASMJS_TARGET := javascript/olm_legacy.js
 WASM_TARGET := $(BUILD_DIR)/wasm/libolm.a
 
 JS_EXPORTED_FUNCTIONS := javascript/exported_functions.json
-JS_EXPORTED_RUNTIME_METHODS := [stackAlloc,writeAsciiToMemory,intArrayFromString,UTF8ToString,stringToUTF8]
+JS_EXPORTED_RUNTIME_METHODS := [stackAlloc,stringToAscii,intArrayFromString,UTF8ToString,stringToUTF8]
 JS_EXTERNS := javascript/externs.js
 
 PUBLIC_HEADERS := include/olm/olm.h include/olm/outbound_group_session.h include/olm/inbound_group_session.h include/olm/pk.h include/olm/sas.h include/olm/error.h include/olm/olm_export.h

--- a/javascript/olm_inbound_group_session.js
+++ b/javascript/olm_inbound_group_session.js
@@ -104,14 +104,14 @@ InboundGroupSession.prototype['decrypt'] = restore_stack(function(
 
     try {
         message_buffer = malloc(message.length);
-        writeAsciiToMemory(message, message_buffer, true);
+        stringToAscii(message, message_buffer);
 
         var max_plaintext_length = inbound_group_session_method(
             Module['_olm_group_decrypt_max_plaintext_length']
         )(this.ptr, message_buffer, message.length);
 
         // caculating the length destroys the input buffer, so we need to re-copy it.
-        writeAsciiToMemory(message, message_buffer, true);
+        stringToAscii(message, message_buffer);
 
         plaintext_buffer = malloc(max_plaintext_length + NULL_BYTE_PADDING_LENGTH);
         var message_index = stack(4);

--- a/javascript/olm_post.js
+++ b/javascript/olm_post.js
@@ -481,14 +481,14 @@ Session.prototype['decrypt'] = restore_stack(function(
 
     try {
         message_buffer = malloc(message.length);
-        writeAsciiToMemory(message, message_buffer, true);
+        stringToAscii(message, message_buffer);
 
         max_plaintext_length = session_method(
             Module['_olm_decrypt_max_plaintext_length']
         )(this.ptr, message_type, message_buffer, message.length);
 
         // caculating the length destroys the input buffer, so we need to re-copy it.
-        writeAsciiToMemory(message, message_buffer, true);
+        stringToAscii(message, message_buffer);
 
         plaintext_buffer = malloc(max_plaintext_length + NULL_BYTE_PADDING_LENGTH);
 


### PR DESCRIPTION
According to https://github.com/emscripten-core/emscripten/pull/19103/files#diff-e61ab498240adc63bb4b7c592573f21e00a357b5d11942e39fd5a3726e667d37R62 we should use ```stringToAscii``` instead of ```writeAsciiToMemory``` which was make build js failing. Replacing the new method and the result it as below.

![Screenshot 2024-06-17 at 20 29 16](https://github.com/famedly/olm/assets/165782748/7ac207fd-9bd2-444d-9431-ebca4642dfc9)
